### PR TITLE
Fix Token class

### DIFF
--- a/src/Authorize/Token.php
+++ b/src/Authorize/Token.php
@@ -3,6 +3,7 @@
 namespace TrueLayer\Authorize;
 
 use DateTime;
+use DateInterval;
 use DateTinterval;
 
 class Token
@@ -17,6 +18,7 @@ class Token
     protected $token_type;
     protected $refresh_token;
     protected $issued_at;
+    protected $issued_at_unformatted;
 
     /**
      * Build our token
@@ -34,9 +36,11 @@ class Token
             $token['refresh_token'] : 
             null;
 
-        $this->issued_at = isset($token['issued_at']) ?  
-            (new DateTime($token['issued_at']))->format(DateTime::ATOM) : 
-            (new DateTime)->format(DateTime::ATOM);
+        $this->issued_at_unformatted = isset($token['issued_at']) ?
+            (new DateTime($token['issued_at'])) :
+            (new DateTime);
+
+        $this->issued_at = $this->issued_at_unformatted->format(DateTime::ATOM);
     }
 
     /**
@@ -66,8 +70,8 @@ class Token
      */
     public function isExpired()
     {
-        $interval = new DateInterval("PT" + $this->expires_in);
-        $expires = (clone $this->issued_at)
+        $interval = new DateInterval("PT" . $this->expires_in . "S");
+        $expires = (clone $this->issued_at_unformatted)
             ->add($interval);
         
         return $expires < (new DateTime);


### PR DESCRIPTION
declare use of DateInterval; save unformatted version of `issued_at` for calculation; fix DateInterval constructor; 

I was receiving errors because of these using PHP 7.2.11