### PR TITLE
fix 2x 'use' statements in Token.php

### DIFF
--- a/src/Authorize/Token.php
+++ b/src/Authorize/Token.php
@@ -4,8 +4,6 @@ namespace TrueLayer\Authorize;
 
 use DateInterval;
 use DateTime;
-use DateInterval;
-use DateTinterval;
 
 class Token
 {


### PR DESCRIPTION
As far as I could tell `DateTInterval` is undefined.