### PR TITLE
Using $path variable in Connection->get() method

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -280,7 +280,7 @@ class Connection
         $result = $this->connection
             ->request(
                 "GET",
-                $this->getUrl("/data/v1/accounts"),
+                $this->getUrl($path),
                 [
                     'headers' => ((bool)$this->access_token ?
                         $this->getBearerHeader() :


### PR DESCRIPTION
Unsure if this is as expected, however I find it misleading that the first param would be unused.

Tests passing still :+1: 