### PR TITLE
Adding some assertions for query string keys returned by getAuthorizationLink() method

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -26,6 +26,17 @@ class ConnectionTest extends TestCase
         ));
 
         $url = filter_var($connection->getAuthorizationLink(), FILTER_VALIDATE_URL);
-        $this->assertTrue((bool)$url);
+        $this->assertTrue((bool) $url);
+        $this->assertStringContainsString('response_type', $url);
+        $this->assertStringContainsString('client_id', $url);
+        $this->assertStringContainsString('test_id', $url);
+        $this->assertStringContainsString('nonce', $url);
+        $this->assertStringContainsString('scope', $url);
+        $this->assertStringContainsString('redirect_uri', $url);
+        $this->assertStringContainsString('enable_mock', $url);
+        $this->assertStringContainsString('enable_oauth_providers', $url);
+        $this->assertStringContainsString('enable_open_banking_providers', $url);
+        $this->assertStringContainsString('enable_credentials_sharing_providers', $url);
+        $this->assertStringContainsString('response_mode', $url);
     }
 }


### PR DESCRIPTION
Extending the existing test which validates that a url is valid.
Adding these assertions will check that `Connection->getAuthorizationLink()` returns a string with the correct keys.