### PR TITLE
Reusable oauth check method + tests

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -2,8 +2,11 @@
 
 namespace TrueLayer;
 
+use Psr\Http\Message\ResponseInterface;
+use Teapot\StatusCode\Http;
 use TrueLayer\Authorize\Token;
 use TrueLayer\Exceptions\InvalidCodeExchange;
+use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Exceptions\TokenExpiredAndNotRefreshable;
 
 class Request
@@ -45,5 +48,16 @@ class Request
 
         $this->connection = $connection;
         $this->token = $token;
+    }
+
+    /**
+     * @param ResponseInterface $result
+     * @throws OauthTokenInvalid
+     */
+    public function OAuthCheck(ResponseInterface $result)
+    {
+        if ($result->getStatusCode() > Http::BAD_REQUEST) {
+            throw new OauthTokenInvalid();
+        }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -56,7 +56,7 @@ class Request
      */
     public function OAuthCheck(ResponseInterface $result)
     {
-        if ($result->getStatusCode() > Http::BAD_REQUEST) {
+        if ($result->getStatusCode() >= Http::BAD_REQUEST) {
             throw new OauthTokenInvalid();
         }
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,31 +1,28 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use TrueLayer\Connection;
 
 class ConnectionTest extends TestCase
 {
+    private $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = $this->createTestConnection();
+    }
+
     public function testWeCanSetClientIdAndSecret()
     {
-        $connection = (new \TrueLayer\Connection(
-            "test_id",
-            "test_secret",
-            "https://localhost.test"
-        ));
-
-        $this->assertSame("test_id", $connection->getClientId());
-        $this->assertSame("test_secret", $connection->getClientSecret());
-        $this->assertSame("https://localhost.test", $connection->getRequestUri());
+        $this->assertSame("test_id", $this->connection->getClientId());
+        $this->assertSame("test_secret", $this->connection->getClientSecret());
+        $this->assertSame("https://localhost.test", $this->connection->getRequestUri());
     }
 
     public function testWeGetAnAuthorizationLink()
     {
-        $connection = (new \TrueLayer\Connection(
-            "test_id",
-            "test_secret",
-            "https://localhost.test"
-        ));
 
-        $url = filter_var($connection->getAuthorizationLink(), FILTER_VALIDATE_URL);
+        $url = filter_var($this->connection->getAuthorizationLink(), FILTER_VALIDATE_URL);
         $this->assertTrue((bool) $url);
         $this->assertStringContainsString('response_type', $url);
         $this->assertStringContainsString('client_id', $url);
@@ -38,5 +35,14 @@ class ConnectionTest extends TestCase
         $this->assertStringContainsString('enable_open_banking_providers', $url);
         $this->assertStringContainsString('enable_credentials_sharing_providers', $url);
         $this->assertStringContainsString('response_mode', $url);
+    }
+
+    public static function createTestConnection(): Connection
+    {
+        return new Connection(
+            "test_id",
+            "test_secret",
+            "https://localhost.test"
+        );
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -9,17 +9,6 @@ use TrueLayer\Request;
 
 class RequestTest extends TestCase
 {
-    private $http;
-
-    public function setUp(): void
-    {
-        $this->http = new GuzzleHttp\Client(['base_uri' => 'https://127.0.0.1']);
-    }
-
-    public function tearDown(): void {
-        $this->http = null;
-    }
-
     public function testOauthCheck()
     {
         $request = new Request(ConnectionTest::createTestConnection(), TokenTest::createTestToken());

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Teapot\StatusCode\Http;
+use TrueLayer\Authorize\TokenTest;
+use TrueLayer\Exceptions\OauthTokenInvalid;
+use TrueLayer\Request;
+
+class RequestTest extends TestCase
+{
+    private $http;
+
+    public function setUp(): void
+    {
+        $this->http = new GuzzleHttp\Client(['base_uri' => 'https://127.0.0.1']);
+    }
+
+    public function tearDown(): void {
+        $this->http = null;
+    }
+
+    public function testOauthCheck()
+    {
+        $request = new Request(ConnectionTest::createTestConnection(), TokenTest::createTestToken());
+        $response = new Response(Http::BAD_REQUEST, ['X-Foo' => 'Bar']);
+        $this->expectException(
+            OauthTokenInvalid::class
+        );
+
+        $request->OAuthCheck($response);
+    }
+}

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TrueLayer\Authorize;
+
+use PHPUnit\Framework\TestCase;
+
+class TokenTest extends TestCase
+{
+    public static function createTestToken($token = 'ExampleToken', $type = 'token')
+    {
+        return new Token([
+            'access_token' => $token,
+            'expires_in' => 100000, // Seconds to expiry
+            'token_type' => $type,
+        ]);
+    }
+
+    public function testCreateTestToken()
+    {
+        // TODO: Improve this test, it's mainly here to avoid PHPUnits warning
+        $token = $this->createTestToken('AnotherToken', 'token');
+        $this->assertInstanceOf(Token::class, $token);
+    }
+}


### PR DESCRIPTION
This solves @kgdiem's issue
https://github.com/waxim/TrueLayer/issues/3

This also helps with testing in the future by providing methods to create test Token & Connection objects.

Will change the repeated conditions to use this method in another PR so it's easier to review.