### PR TITLE
Using new reusable oAuthCheck

### DIFF
--- a/src/Bank/Account/Balance.php
+++ b/src/Bank/Account/Balance.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Account;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Balance as Data;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Account/Balance.php
+++ b/src/Bank/Account/Balance.php
@@ -23,10 +23,7 @@ class Balance extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/balance");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new Data($data["results"]);

--- a/src/Bank/Account/Balance.php
+++ b/src/Bank/Account/Balance.php
@@ -22,7 +22,7 @@ class Balance extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/balance");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new Data($data["results"]);

--- a/src/Bank/Account/Information.php
+++ b/src/Bank/Account/Information.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Account;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Account;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Account/Information.php
+++ b/src/Bank/Account/Information.php
@@ -23,10 +23,7 @@ class Information extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id);
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new Account($data["results"]);

--- a/src/Bank/Account/Information.php
+++ b/src/Bank/Account/Information.php
@@ -22,7 +22,7 @@ class Information extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id);
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new Account($data["results"]);

--- a/src/Bank/Account/PendingTransactions.php
+++ b/src/Bank/Account/PendingTransactions.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Account;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Transaction;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Account/PendingTransactions.php
+++ b/src/Bank/Account/PendingTransactions.php
@@ -23,10 +23,7 @@ class PendingTransactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/transactions/pending");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new Transaction($value);

--- a/src/Bank/Account/PendingTransactions.php
+++ b/src/Bank/Account/PendingTransactions.php
@@ -22,7 +22,7 @@ class PendingTransactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/transactions/pending");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new Transaction($value);

--- a/src/Bank/Account/Transactions.php
+++ b/src/Bank/Account/Transactions.php
@@ -31,7 +31,7 @@ class Transactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/transactions", $params);
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new Transaction($value);

--- a/src/Bank/Account/Transactions.php
+++ b/src/Bank/Account/Transactions.php
@@ -32,10 +32,7 @@ class Transactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts/" . $account_id . "/transactions", $params);
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new Transaction($value);

--- a/src/Bank/Account/Transactions.php
+++ b/src/Bank/Account/Transactions.php
@@ -3,7 +3,6 @@
 namespace TrueLayer\Bank\Account;
 
 use DateTime;
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Transaction;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Accounts.php
+++ b/src/Bank/Accounts.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Account;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Accounts.php
+++ b/src/Bank/Accounts.php
@@ -22,10 +22,7 @@ class Accounts extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $accounts = json_decode($result->getBody(), true);
         $results = array_walk($accounts['results'], function ($value) {
             return new Account($value);

--- a/src/Bank/Accounts.php
+++ b/src/Bank/Accounts.php
@@ -21,7 +21,7 @@ class Accounts extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/accounts");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $accounts = json_decode($result->getBody(), true);
         $results = array_walk($accounts['results'], function ($value) {
             return new Account($value);

--- a/src/Bank/Card/Balance.php
+++ b/src/Bank/Card/Balance.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Card;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\CardBalance;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Card/Balance.php
+++ b/src/Bank/Card/Balance.php
@@ -22,7 +22,7 @@ class Balance extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/balance");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new CardBalance($data['results']);

--- a/src/Bank/Card/Balance.php
+++ b/src/Bank/Card/Balance.php
@@ -23,10 +23,7 @@ class Balance extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/balance");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return new CardBalance($data['results']);

--- a/src/Bank/Card/Information.php
+++ b/src/Bank/Card/Information.php
@@ -23,9 +23,8 @@ class Information extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id);
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
+        $this->OAuthCheck($result);
+
 
         $data = json_decode($result->getBody(), true);
 

--- a/src/Bank/Card/Information.php
+++ b/src/Bank/Card/Information.php
@@ -24,7 +24,6 @@ class Information extends Request
 
         $this->OAuthCheck($result);
 
-
         $data = json_decode($result->getBody(), true);
 
         return new Card($data['results']);

--- a/src/Bank/Card/Information.php
+++ b/src/Bank/Card/Information.php
@@ -22,7 +22,7 @@ class Information extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id);
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
 
         $data = json_decode($result->getBody(), true);
 

--- a/src/Bank/Card/Information.php
+++ b/src/Bank/Card/Information.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Card;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Card;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Card/PendingTransactions.php
+++ b/src/Bank/Card/PendingTransactions.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank\Card;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\CardTransaction;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Card/PendingTransactions.php
+++ b/src/Bank/Card/PendingTransactions.php
@@ -23,11 +23,7 @@ class PendingTransactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/transactions/pending");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
-        $data = json_decode($result->getBody(), true);
+        $this->OAuthCheck($result);$data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new CardTransaction($value);
         });

--- a/src/Bank/Card/PendingTransactions.php
+++ b/src/Bank/Card/PendingTransactions.php
@@ -22,7 +22,8 @@ class PendingTransactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/transactions/pending");
 
-        $this->OAuthCheck($result);$data = json_decode($result->getBody(), true);
+        $this->OAuthCheck($result);
+        $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new CardTransaction($value);
         });

--- a/src/Bank/Card/PendingTransactions.php
+++ b/src/Bank/Card/PendingTransactions.php
@@ -22,7 +22,7 @@ class PendingTransactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/transactions/pending");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new CardTransaction($value);

--- a/src/Bank/Card/Transactions.php
+++ b/src/Bank/Card/Transactions.php
@@ -31,7 +31,7 @@ class Transactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/transactions", $params);
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new CardTransaction($value);

--- a/src/Bank/Card/Transactions.php
+++ b/src/Bank/Card/Transactions.php
@@ -3,7 +3,6 @@
 namespace TrueLayer\Bank\Card;
 
 use DateTime;
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\CardTransaction;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Card/Transactions.php
+++ b/src/Bank/Card/Transactions.php
@@ -32,10 +32,7 @@ class Transactions extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards/" . $account_id . "/transactions", $params);
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
         $results = array_walk($data['results'], function ($value) {
             return new CardTransaction($value);

--- a/src/Bank/Cards.php
+++ b/src/Bank/Cards.php
@@ -21,7 +21,7 @@ class Cards extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $accounts = json_decode($result->getBody(), true);
         $results = array_walk($accounts['results'], function ($value) {
             return new Card($value);

--- a/src/Bank/Cards.php
+++ b/src/Bank/Cards.php
@@ -22,10 +22,7 @@ class Cards extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/cards");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $accounts = json_decode($result->getBody(), true);
         $results = array_walk($accounts['results'], function ($value) {
             return new Card($value);

--- a/src/Bank/Cards.php
+++ b/src/Bank/Cards.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Card;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Identity.php
+++ b/src/Bank/Identity.php
@@ -21,7 +21,7 @@ class Identity extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/info");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
         return new Customer($data['results']);
     }

--- a/src/Bank/Identity.php
+++ b/src/Bank/Identity.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer\Bank;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Data\Customer;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;

--- a/src/Bank/Identity.php
+++ b/src/Bank/Identity.php
@@ -22,10 +22,7 @@ class Identity extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/info");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
         return new Customer($data['results']);
     }

--- a/src/Me.php
+++ b/src/Me.php
@@ -19,7 +19,7 @@ class Me extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/me");
 
-        $this->OAuthCheck($result);
+        $this->statusCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return $data;

--- a/src/Me.php
+++ b/src/Me.php
@@ -2,7 +2,6 @@
 
 namespace TrueLayer;
 
-use Teapot\StatusCode\Http;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 
 class Me extends Request

--- a/src/Me.php
+++ b/src/Me.php
@@ -20,10 +20,7 @@ class Me extends Request
             ->setAccessToken($this->token->getAccessToken())
             ->get("/data/v1/me");
 
-        if ((int) $result->getStatusCode() > Http::BAD_REQUEST) {
-            throw new OauthTokenInvalid();
-        }
-
+        $this->OAuthCheck($result);
         $data = json_decode($result->getBody(), true);
 
         return $data;

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,8 +2,11 @@
 
 namespace TrueLayer;
 
+use Psr\Http\Message\ResponseInterface;
+use Teapot\StatusCode\Http;
 use TrueLayer\Authorize\Token;
 use TrueLayer\Exceptions\InvalidCodeExchange;
+use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Exceptions\TokenExpiredAndNotRefreshable;
 
 class Request
@@ -45,5 +48,16 @@ class Request
 
         $this->connection = $connection;
         $this->token = $token;
+    }
+
+    /**
+     * @param ResponseInterface $result
+     * @throws OauthTokenInvalid
+     */
+    public function OAuthCheck(ResponseInterface $result)
+    {
+        if ($result->getStatusCode() > Http::BAD_REQUEST) {
+            throw new OauthTokenInvalid();
+        }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -56,7 +56,7 @@ class Request
      */
     public function OAuthCheck(ResponseInterface $result)
     {
-        if ($result->getStatusCode() > Http::BAD_REQUEST) {
+        if ($result->getStatusCode() >= Http::BAD_REQUEST) {
             throw new OauthTokenInvalid();
         }
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -54,7 +54,7 @@ class Request
      * @param ResponseInterface $result
      * @throws OauthTokenInvalid
      */
-    public function OAuthCheck(ResponseInterface $result)
+    public function statusCheck(ResponseInterface $result)
     {
         if ($result->getStatusCode() >= Http::BAD_REQUEST) {
             throw new OauthTokenInvalid();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,31 +1,28 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use TrueLayer\Connection;
 
 class ConnectionTest extends TestCase
 {
+    private $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = $this->createTestConnection();
+    }
+
     public function testWeCanSetClientIdAndSecret()
     {
-        $connection = (new \TrueLayer\Connection(
-            "test_id",
-            "test_secret",
-            "https://localhost.test"
-        ));
-
-        $this->assertSame("test_id", $connection->getClientId());
-        $this->assertSame("test_secret", $connection->getClientSecret());
-        $this->assertSame("https://localhost.test", $connection->getRequestUri());
+        $this->assertSame("test_id", $this->connection->getClientId());
+        $this->assertSame("test_secret", $this->connection->getClientSecret());
+        $this->assertSame("https://localhost.test", $this->connection->getRequestUri());
     }
 
     public function testWeGetAnAuthorizationLink()
     {
-        $connection = (new \TrueLayer\Connection(
-            "test_id",
-            "test_secret",
-            "https://localhost.test"
-        ));
 
-        $url = filter_var($connection->getAuthorizationLink(), FILTER_VALIDATE_URL);
+        $url = filter_var($this->connection->getAuthorizationLink(), FILTER_VALIDATE_URL);
         $this->assertTrue((bool) $url);
         $this->assertStringContainsString('response_type', $url);
         $this->assertStringContainsString('client_id', $url);
@@ -38,5 +35,14 @@ class ConnectionTest extends TestCase
         $this->assertStringContainsString('enable_open_banking_providers', $url);
         $this->assertStringContainsString('enable_credentials_sharing_providers', $url);
         $this->assertStringContainsString('response_mode', $url);
+    }
+
+    public static function createTestConnection(): Connection
+    {
+        return new Connection(
+            "test_id",
+            "test_secret",
+            "https://localhost.test"
+        );
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -9,17 +9,6 @@ use TrueLayer\Request;
 
 class RequestTest extends TestCase
 {
-    private $http;
-
-    public function setUp(): void
-    {
-        $this->http = new GuzzleHttp\Client(['base_uri' => 'https://127.0.0.1']);
-    }
-
-    public function tearDown(): void {
-        $this->http = null;
-    }
-
     public function testOauthCheck()
     {
         $request = new Request(ConnectionTest::createTestConnection(), TokenTest::createTestToken());

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Teapot\StatusCode\Http;
+use TrueLayer\Authorize\TokenTest;
+use TrueLayer\Exceptions\OauthTokenInvalid;
+use TrueLayer\Request;
+
+class RequestTest extends TestCase
+{
+    private $http;
+
+    public function setUp(): void
+    {
+        $this->http = new GuzzleHttp\Client(['base_uri' => 'https://127.0.0.1']);
+    }
+
+    public function tearDown(): void {
+        $this->http = null;
+    }
+
+    public function testOauthCheck()
+    {
+        $request = new Request(ConnectionTest::createTestConnection(), TokenTest::createTestToken());
+        $response = new Response(Http::BAD_REQUEST, ['X-Foo' => 'Bar']);
+        $this->expectException(
+            OauthTokenInvalid::class
+        );
+
+        $request->OAuthCheck($response);
+    }
+}

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace TrueLayer\Authorize;
+
+use PHPUnit\Framework\TestCase;
+
+class TokenTest extends TestCase
+{
+    public static function createTestToken($token = 'ExampleToken', $type = 'token')
+    {
+        return new Token([
+            'access_token' => $token,
+            'expires_in' => 100000, // Seconds to expiry
+            'token_type' => $type,
+        ]);
+    }
+
+    public function testCreateTestToken()
+    {
+        // TODO: Improve this test, it's mainly here to avoid PHPUnits warning
+        $token = $this->createTestToken('AnotherToken', 'token');
+        $this->assertInstanceOf(Token::class, $token);
+    }
+}


### PR DESCRIPTION
Combined with my other pr #15, this will allow methods to check oauth by calling a reusable method on the `Request` class.

Once the other PR is merged, the diff of this one will be purely me changing the condition for method call and removing unused class depenency of `Teapot\StatusCode\Http`