### PR TITLE
Returning an array of Transitions from PendingTransactions -> get

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "require": {
     "guzzlehttp/guzzle": "^6.3",
     "ext-json": "*",
-    "teapot/status-code": "^1.1"
+    "teapot/status-code": "^1.1",
+    "guzzlehttp/streams": "^3.0"
   },
   "require-dev": {
     "filp/whoops": "^2.3",

--- a/mocks/pending-transactions.json
+++ b/mocks/pending-transactions.json
@@ -1,0 +1,40 @@
+{
+  "results": [
+    {
+      "transaction_id": "03c333979b729315545816aaa365c33f",
+      "timestamp": "2018-11-18T00:00:00",
+      "description": "GOOGLE PLAY STORE",
+      "amount": -2.99,
+      "currency": "GBP",
+      "transaction_type": "DEBIT",
+      "transaction_category": "PURCHASE",
+      "transaction_classification": [
+        "Entertainment",
+        "Games"
+      ],
+      "merchant_name": "Google play",
+      "meta": {
+        "bank_transaction_id": "9882ks-00js",
+        "provider_transaction_category": "DEB"
+      }
+    },
+    {
+      "transaction_id": "3484333edb2078e77cf2ed58f1dec11e",
+      "timestamp": "2018-11-18T00:00:00",
+      "description": "PAYPAL EBAY",
+      "amount": -25.25,
+      "currency": "GBP",
+      "transaction_type": "DEBIT",
+      "transaction_category": "PURCHASE",
+      "transaction_classification": [
+        "Shopping",
+        "General"
+      ],
+      "merchant_name": "Ebay",
+      "meta": {
+        "bank_transaction_id": "33b5555724",
+        "provider_transaction_category": "DEB"
+      }
+    }
+  ]
+}

--- a/src/Bank/Account/PendingTransactions.php
+++ b/src/Bank/Account/PendingTransactions.php
@@ -13,7 +13,7 @@ class PendingTransactions extends Request
      * Get pending transactions
      *
      * @param string $account_id
-     * @return Transaction|array
+     * @return array
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws OauthTokenInvalid
      */
@@ -28,10 +28,13 @@ class PendingTransactions extends Request
         }
 
         $data = json_decode($result->getBody(), true);
-        $results = array_walk($data['results'], function ($value) {
-            return new Transaction($value);
-        });
 
-        return $results;
+        $transactions = [];
+
+        foreach($data['results'] as $result) {
+            $transactions[] = (new Transaction($result));
+        }
+
+        return $transactions;
     }
 }

--- a/src/Bank/Account/PendingTransactions.php
+++ b/src/Bank/Account/PendingTransactions.php
@@ -31,8 +31,8 @@ class PendingTransactions extends Request
 
         $transactions = [];
 
-        foreach($data['results'] as $result) {
-            $transactions[] = (new Transaction($result));
+        foreach($data['results'] as $key => $result) {
+            $transactions[$key] = new Transaction($result);
         }
 
         return $transactions;

--- a/tests/Bank/Account/PendingTransactionsTest.php
+++ b/tests/Bank/Account/PendingTransactionsTest.php
@@ -7,6 +7,7 @@ use Teapot\StatusCode\Http;
 use TrueLayer\Authorize\Token;
 use TrueLayer\Bank\Account\PendingTransactions;
 use TrueLayer\Connection;
+use TrueLayer\Data\Transaction;
 
 class PendingTransactionsTest extends TestCase
 {
@@ -42,16 +43,24 @@ class PendingTransactionsTest extends TestCase
 
         $this->assertIsNotBool($pt);
         $this->assertIsArray($pt);
-        $this->assertArrayHasKey('transaction_id', $pt[0]);
-        $this->assertArrayHasKey('timestamp', $pt[0]);
-        $this->assertArrayHasKey('description', $pt[0]);
-        $this->assertArrayHasKey('amount', $pt[0]);
-        $this->assertArrayHasKey('currency', $pt[0]);
-        $this->assertArrayHasKey('transaction_type', $pt[0]);
-        $this->assertArrayHasKey('transaction_category', $pt[0]);
-        $this->assertArrayHasKey('transaction_classification', $pt[0]);
-        $this->assertArrayHasKey('merchant_name', $pt[0]);
-        $this->assertArrayHasKey('bank_transaction_id', $pt[0]['meta']);
-        $this->assertArrayHasKey('provider_transaction_category', $pt[0]['meta']);
+        $this->assertInstanceOf(Transaction::class, $pt[0]);
+
+        $attributes = [
+            'id',
+            'timestamp',
+            'description',
+            'amount',
+            'currency',
+            'type',
+            'category',
+            'classification',
+            'merchant_name',
+            'meta',
+            'category',
+        ];
+
+        foreach ($attributes as $attribute) {
+            $this->assertObjectHasAttribute($attribute, $pt[0]);
+        }
     }
 }

--- a/tests/Bank/Account/PendingTransactionsTest.php
+++ b/tests/Bank/Account/PendingTransactionsTest.php
@@ -38,7 +38,7 @@ class PendingTransactionsTest extends TestCase
 
         $pendingTransactions = new PendingTransactions($connection, $token);
 
-         $pt = $pendingTransactions->get(1);
+        $pt = $pendingTransactions->get(1);
 
         $this->assertIsNotBool($pt);
         $this->assertIsArray($pt);

--- a/tests/Bank/Account/PendingTransactionsTest.php
+++ b/tests/Bank/Account/PendingTransactionsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Stream\Stream;
+use PHPUnit\Framework\TestCase;
+use Teapot\StatusCode\Http;
+use TrueLayer\Authorize\Token;
+use TrueLayer\Bank\Account\PendingTransactions;
+use TrueLayer\Connection;
+
+class PendingTransactionsTest extends TestCase
+{
+    public function testGetReturnsAnArrayAndNotABoolean()
+    {
+        $connection = $this->createMock(Connection::class);
+        $token = $this->createMock(Token::class);
+        $token
+            ->method('isExpired')
+            ->willReturn(false);
+
+        $response = new Response(
+            Http::OK,
+            ['Example' => 'headers'],
+            Stream::factory(file_get_contents(__DIR__.'../../../../mocks/pending-transactions.json'))
+        );
+
+        $connection
+            ->method('getOauthToken')
+            ->willReturn($token);
+
+        $connection
+            ->method('setAccessToken')
+            ->willReturn($connection);
+
+        $connection
+            ->method('get')
+            ->willReturn($response);
+
+        $pt = new PendingTransactions($connection, $token);
+
+        $this->assertIsNotBool(
+            $pt->get(12)
+        );
+
+        $this->assertIsArray(
+            $pt->get(34)
+        );
+    }
+}

--- a/tests/Bank/Account/PendingTransactionsTest.php
+++ b/tests/Bank/Account/PendingTransactionsTest.php
@@ -36,14 +36,22 @@ class PendingTransactionsTest extends TestCase
             ->method('get')
             ->willReturn($response);
 
-        $pt = new PendingTransactions($connection, $token);
+        $pendingTransactions = new PendingTransactions($connection, $token);
 
-        $this->assertIsNotBool(
-            $pt->get(12)
-        );
+         $pt = $pendingTransactions->get(1);
 
-        $this->assertIsArray(
-            $pt->get(34)
-        );
+        $this->assertIsNotBool($pt);
+        $this->assertIsArray($pt);
+        $this->assertArrayHasKey('transaction_id', $pt[0]);
+        $this->assertArrayHasKey('timestamp', $pt[0]);
+        $this->assertArrayHasKey('description', $pt[0]);
+        $this->assertArrayHasKey('amount', $pt[0]);
+        $this->assertArrayHasKey('currency', $pt[0]);
+        $this->assertArrayHasKey('transaction_type', $pt[0]);
+        $this->assertArrayHasKey('transaction_category', $pt[0]);
+        $this->assertArrayHasKey('transaction_classification', $pt[0]);
+        $this->assertArrayHasKey('merchant_name', $pt[0]);
+        $this->assertArrayHasKey('bank_transaction_id', $pt[0]['meta']);
+        $this->assertArrayHasKey('provider_transaction_category', $pt[0]['meta']);
     }
 }


### PR DESCRIPTION
A great spot by @kgdiem. It was noticed that `array_walk` returns a bool and we were returning this value, assuming it would return an array.

This test covers that problem and will check for the expected keys.

This test will fail currently, until #6 is merged.