### PR TITLE
Moving data resolver to its own class and testing it

### DIFF
--- a/src/Banking/AbstractResolver.php
+++ b/src/Banking/AbstractResolver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TrueLayer\Banking;
+
+abstract class AbstractResolver
+{
+
+}

--- a/src/Banking/DataResolver.php
+++ b/src/Banking/DataResolver.php
@@ -4,7 +4,7 @@ namespace TrueLayer\Banking;
 
 use TrueLayer\Data\Status;
 
-class DataResolver
+class DataResolver extends AbstractResolver
 {
     /**
      * @param array $results

--- a/src/Banking/DataResolver.php
+++ b/src/Banking/DataResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TrueLayer\Banking;
+
+use TrueLayer\Data\Status;
+
+class DataResolver
+{
+    /**
+     * @param array $results
+     * @return array
+     */
+    public function getAvailability($results)
+    {
+        $availability = [];
+
+        foreach($results['results'] as $result) {
+            foreach($result['providers'] as $name => $p){
+                $status = new Status();
+                $status->name = $p['provider_id'];
+                foreach($p['endpoints'] as $ep) {
+                    if($ep['endpoint'] === "accounts") {
+                        $status->accounts = $ep['availability'];
+                    }
+
+                    if($ep['endpoint'] === "accounts/transactions") {
+                        $status->transactions = $ep['availability'];
+                    }
+
+                    if($ep['endpoint'] === "cards") {
+                        $status->cards = $ep['availability'];
+                    }
+
+                    if($ep['endpoint'] === "info") {
+                        $status->pii = $ep['availability'];
+                    }
+                }
+                $availability[$status->name] = $status;
+            }
+        }
+
+        return $availability;
+    }
+}

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -8,6 +8,7 @@ use Teapot\StatusCode\Http;
 use TrueLayer\Authorize\Token;
 use TrueLayer\Exceptions\InvalidCodeExchange;
 use TrueLayer\Data\Status;
+use TrueLayer\Exceptions\UnresolvableResult;
 
 class Connection
 {
@@ -41,6 +42,7 @@ class Connection
     protected $access_token;
     protected $scope;
     protected $state;
+    protected $data_resolver = Banking\DataResolver::class;
 
     /**
      * Set values and start a guzzle
@@ -314,7 +316,7 @@ class Connection
     /**
      * A function to get our statuses for
      * each bank for the last 24 hours
-     * 
+     *
      * @param DateTime $from
      * @param DateTime $to
      * @param array $providers
@@ -345,34 +347,26 @@ class Connection
             throw new InvalidCodeExchange;
         }
 
-        $availability = [];
-        $results = json_decode($result->getBody(), true);
- 
-        foreach($results['results'] as $result) {
-            foreach($result['providers'] as $name => $p){
-                $status = new Status();
-                $status->name = $p['provider_id'];
-                foreach($p['endpoints'] as $ep) {
-                    if($ep['endpoint'] === "accounts") {          
-                        $status->accounts = $ep['availability'];
-                    }
+        return $this->resolver(json_decode($result->getBody(), true), __FUNCTION__);
+    }
 
-                    if($ep['endpoint'] === "accounts/transactions") {
-                        $status->transactions = $ep['availability'];
-                    }
-
-                    if($ep['endpoint'] === "cards") {
-                        $status->cards = $ep['availability'];
-                    }
-
-                    if($ep['endpoint'] === "info") {
-                        $status->pii = $ep['availability'];
-                    }
-                }
-                $availability[$status->name] = $status;
-            }
+    /**
+     * @param $results
+     * @param $function
+     * @return mixed
+     * @throws UnresolvableResult
+     */
+    public function resolver($results, $function)
+    {
+        if (false === method_exists($this->data_resolver, $function)) {
+            throw new UnresolvableResult($function);
         }
 
-        return $availability;
+        return $this->data_resolver->{$function}($results);
+    }
+
+    public function setDataResolver($resolver)
+    {
+        $this->data_resolver = $resolver;
     }
 }

--- a/src/Data/Status.php
+++ b/src/Data/Status.php
@@ -35,7 +35,7 @@ class Status
     /**
      * accounts
      *
-     * @var double
+     * @var int|double
      */
     public $accounts;
 }

--- a/src/Exceptions/UnresolvableResult.php
+++ b/src/Exceptions/UnresolvableResult.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TrueLayer\Exceptions;
+
+class UnresolvableResult extends \Exception
+{
+    protected $message = 'The given result was not resolvable.';
+}

--- a/tests/Banking/DataResolverTest.php
+++ b/tests/Banking/DataResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TrueLayer\Tests\Banking;
+
+use TrueLayer\Banking\DataResolver;
+use TrueLayer\Data\Status;
+use TrueLayer\Exceptions\UnresolvableResult;
+use TrueLayer\Tests\TestCase;
+use TrueLayer\Tests\Traits\HasConnectionTrait;
+
+class DataResolverTest extends TestCase
+{
+    use HasConnectionTrait;
+
+    public function testWhenResolverFunctionDoesntExist()
+    {
+        $this->expectException(UnresolvableResult::class);
+        $this->connection->resolver(['results' => []], 'aFunctionWhichDoesNotExist');
+    }
+
+    public function testBankingResolver()
+    {
+        $resolver = new DataResolver();
+
+        $mockData = json_decode($this->getMockResponse('status/availability.json'), true);
+        $providers = $mockData['results'][0]['providers'];
+        $monzoMockData = $providers[0];
+        $starlingMockData = $providers[1];
+
+        $this->assertEquals('oauth-monzo', $monzoMockData['provider_id']);
+        $this->assertEquals('oauth-starling', $starlingMockData['provider_id']);
+
+        $this->connection->setDataResolver($resolver);
+        $resolver = $this->connection->resolver($mockData, 'getAvailability');
+
+        /** @var Status $monzoStatus */
+        $monzoStatus = $resolver[$monzoMockData['provider_id']];
+        /** @var Status $starlingStatus */
+        $starlingStatus = $resolver[$starlingMockData['provider_id']];
+
+        $this->assertInstanceOf(Status::class, $monzoStatus);
+        $this->assertInstanceOf(Status::class, $starlingStatus);
+
+        $this->assertIsNumeric($starlingStatus->accounts);
+        $this->assertIsNumeric($monzoStatus->accounts);
+
+        // TODO: Write a test to sum the availability of multiple providers
+        // https://github.com/waxim/TrueLayer/issues/31
+        // $this->assertSame($monzo['endpoints'][1]['availability'], $monzoStatus->accounts);
+        // $this->assertSame($starling['endpoints'][1]['availability'], $starlingStatus->accounts);
+    }
+}

--- a/tests/Banking/DataResolverTest.php
+++ b/tests/Banking/DataResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace TrueLayer\Tests\Banking;
 
+use TrueLayer\Banking\AbstractResolver;
 use TrueLayer\Banking\DataResolver;
 use TrueLayer\Data\Status;
 use TrueLayer\Exceptions\UnresolvableResult;
@@ -12,10 +13,22 @@ class DataResolverTest extends TestCase
 {
     use HasConnectionTrait;
 
+    public function testAnInstanceOfAbstractResolverIsReturnedByConnection()
+    {
+        $this->assertInstanceOf(AbstractResolver::class, $this->connection->getDataResolver());
+    }
+
+    public function testAnInstanceOfAbstractResolverIsReturnedByConnectionOnceSet()
+    {
+        $this->connection->setDataResolver(new DataResolver());
+        $this->assertInstanceOf(AbstractResolver::class, $this->connection->getDataResolver());
+        $this->assertInstanceOf(DataResolver::class, $this->connection->getDataResolver());
+    }
+
     public function testWhenResolverFunctionDoesntExist()
     {
         $this->expectException(UnresolvableResult::class);
-        $this->connection->resolver(['results' => []], 'aFunctionWhichDoesNotExist');
+        $this->connection->resolve(['results' => []], 'aFunctionWhichDoesNotExist');
     }
 
     public function testBankingResolver()
@@ -31,7 +44,7 @@ class DataResolverTest extends TestCase
         $this->assertEquals('oauth-starling', $starlingMockData['provider_id']);
 
         $this->connection->setDataResolver($resolver);
-        $resolver = $this->connection->resolver($mockData, 'getAvailability');
+        $resolver = $this->connection->resolve($mockData, 'getAvailability');
 
         /** @var Status $monzoStatus */
         $monzoStatus = $resolver[$monzoMockData['provider_id']];

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -2,21 +2,12 @@
 
 namespace TrueLayer\Tests;
 
-use TrueLayer\Banking\DataResolver;
 use TrueLayer\Connection;
-use TrueLayer\Exceptions\UnresolvableResult;
+use TrueLayer\Tests\Traits\HasConnectionTrait;
 
 class ConnectionTest extends TestCase
 {
-    /**
-     * @var Connection
-     */
-    private $connection;
-
-    public function setUp(): void
-    {
-        $this->connection = $this->createTestConnection();
-    }
+    use HasConnectionTrait;
 
     public function testWeCanSetClientIdAndSecret()
     {
@@ -40,14 +31,5 @@ class ConnectionTest extends TestCase
         $this->assertStringContainsString('enable_open_banking_providers', $url);
         $this->assertStringContainsString('enable_credentials_sharing_providers', $url);
         $this->assertStringContainsString('response_mode', $url);
-    }
-
-    public static function createTestConnection()
-    {
-        return new Connection(
-            "test_id",
-            "test_secret",
-            "https://localhost.test"
-        );
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -7,12 +7,15 @@ use PHPUnit\Framework\TestCase;
 use Teapot\StatusCode\Http;
 use TrueLayer\Exceptions\OauthTokenInvalid;
 use TrueLayer\Request;
+use TrueLayer\Tests\Traits\HasConnectionTrait;
 
 class RequestTest extends TestCase
 {
+    use HasConnectionTrait;
+
     public function testOauthCheck()
     {
-        $request = new Request(ConnectionTest::createTestConnection(), TokenTest::createTestToken());
+        $request = new Request($this->connection, TokenTest::createTestToken());
         $response = new Response(Http::BAD_REQUEST, ['X-Foo' => 'Bar']);
         $this->expectException(
             OauthTokenInvalid::class

--- a/tests/Traits/HasConnectionTrait.php
+++ b/tests/Traits/HasConnectionTrait.php
@@ -13,12 +13,7 @@ trait HasConnectionTrait
 
     protected function setUp(): void
     {
-        $this->connection = $this->createTestConnection();
-    }
-
-    protected function createTestConnection()
-    {
-        return new Connection(
+        $this->connection = new Connection(
             "test_id",
             "test_secret",
             "https://localhost.test"

--- a/tests/Traits/HasConnectionTrait.php
+++ b/tests/Traits/HasConnectionTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TrueLayer\Tests\Traits;
+
+use TrueLayer\Connection;
+
+trait HasConnectionTrait
+{
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = $this->createTestConnection();
+    }
+
+    public static function createTestConnection()
+    {
+        return new Connection(
+            "test_id",
+            "test_secret",
+            "https://localhost.test"
+        );
+    }
+}

--- a/tests/Traits/HasConnectionTrait.php
+++ b/tests/Traits/HasConnectionTrait.php
@@ -11,12 +11,12 @@ trait HasConnectionTrait
      */
     protected $connection;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->connection = $this->createTestConnection();
     }
 
-    public static function createTestConnection()
+    protected function createTestConnection()
     {
         return new Connection(
             "test_id",


### PR DESCRIPTION
As we want to handle Async requests, we need to switch out how data is resolved.

This change does the following:
- Adds the ability for a `DataResolver` to be set on a `Connection` class
- Moves the Logic out of the `Connection` class into a new `DataResolver` class
- A new `UnresolvableResult` exception class when the `DataResolver` is not compatible with the request
- Basic tests for `DataResolver` to ensure existing functionality is as is despite moving the logic out
- Adds a `HasConnection` trait, for better organisation when testing
- Moves `createTestConnection` method out to new `HasConnection` trait

Found #31 During writing this. A TODO is in the `DataResolverTest` class.