### PR TITLE
WIP: Add delete token

### DIFF
--- a/src/Authorize/Token.php
+++ b/src/Authorize/Token.php
@@ -4,8 +4,9 @@ namespace TrueLayer\Authorize;
 
 use DateInterval;
 use DateTime;
+use TrueLayer\Request;
 
-class Token
+class Token extends Request
 {
     /**
      * Hold the parts of our token
@@ -86,5 +87,15 @@ class Token
     public function isRefreshable()
     {
         return (bool)$this->refresh_token;
+    }
+
+    /**
+     * Revoke Token
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->connection->delete('/api/delete');
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -45,11 +45,8 @@ class Connection
     protected $scope;
     protected $state;
     protected $data_resolver;
-<<<<<<< HEAD
     protected $sandbox = false;
     protected $provider;
-=======
->>>>>>> 18ed9cb8d73fea973e73d1dcda75143fcd327736
 
     /**
      * Set values and start a guzzle
@@ -60,6 +57,7 @@ class Connection
      * @param array $scope
      * @param null $state
      * @param string $data_resolver
+     * @param string $provider
      */
     public function __construct(
         $client_id,
@@ -67,12 +65,8 @@ class Connection
         $request_uri,
         $scope = [],
         $state = null,
-<<<<<<< HEAD
         $data_resolver = DataResolver::class,
         $provider = null
-=======
-        $data_resolver = DataResolver::class
->>>>>>> 18ed9cb8d73fea973e73d1dcda75143fcd327736
     ) {
         $this->connection = new Client;
         $this->client_id = $client_id;
@@ -81,10 +75,7 @@ class Connection
         $this->scope = $scope;
         $this->state = $state;
         $this->data_resolver = new $data_resolver();
-<<<<<<< HEAD
         $this->provider = $provider;
-=======
->>>>>>> 18ed9cb8d73fea973e73d1dcda75143fcd327736
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -334,6 +334,32 @@ class Connection
     }
 
     /**
+     * A delete proxy which adds our token
+     *
+     * @param string $path
+     * @param string $params
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    function delete($path = "/", $params = [])
+    {
+        $result = $this->connection
+            ->request(
+                "DELETE",
+                $this->getUrl($path),
+                [
+                    'headers' => ((bool) $this->access_token ?
+                        $this->getBearerHeader() :
+                        []
+                    ),
+                    'query' => $params
+                ]
+            );
+
+        return $result;
+    }
+
+    /**
      * Set out access_token
      *
      * @param $token


### PR DESCRIPTION
This is a work in progress. 

Adds support for the `api/delete` endpoint 

https://docs.truelayer.com/#delete-encrypted-credentials